### PR TITLE
- Support for Flutter 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 .pub/
 .lock/
 /build/
+/.fvm/flutter_sdk/
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0
+
+- Support for Flutter 3.7
+- Updated dependencies
+- Improve example app. Note: avoid using setState calls frequently on the page where the CrCalendar
+  widget is used to improve performance.
+
 # 1.0.0+1
 
 - Fixed pub points
@@ -22,7 +29,8 @@
 
 # 0.0.7
 
-- fixed issue with page controller. Added minDate and maxDate properties for date picker and cr calendar
+- fixed issue with page controller. Added minDate and maxDate properties for date picker and cr
+  calendar
 
 # 0.0.6
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ class _MyAppState extends State<MyApp> {
 }
 ```
 
+Note: avoid using setState calls frequently on the page where the CrCalendar widget is used to improve performance.
+
 ### Usage of CrCalendar date picker dialog
 ##### DatePickerProperties parameters:
 |Type|Name|Description|Default value|

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -163,7 +163,6 @@ linter:
     # - diagnostic_describe_all_properties # DO reference all public properties in debug method implementations. # We don't use this
     - empty_statements # AVOID empty statements.
     - hash_and_equals # DO override hashCode if overriding == and prefer overriding == if overriding hashCode.
-    - invariant_booleans # DON'T test for conditions that can be inferred at compile time or test the same condition twice.
     - iterable_contains_unrelated_type # DON'T invoke contains on Iterable with an instance of different type than the parameter type.
     - list_remove_unrelated_type # DON'T invoke remove on List with an instance of different type than the parameter type.
     - literal_only_boolean_expressions # DON'T test for conditions composed only by literals, since the value can be inferred at compile time.

--- a/example/lib/pages/calendar_page.dart
+++ b/example/lib/pages/calendar_page.dart
@@ -1,3 +1,5 @@
+import 'dart:core';
+
 import 'package:cr_calendar/cr_calendar.dart';
 import 'package:cr_calendar_example/res/colors.dart';
 import 'package:cr_calendar_example/utills/constants.dart';
@@ -19,10 +21,10 @@ class CalendarPage extends StatefulWidget {
 
 class _CalendarPageState extends State<CalendarPage> {
   final _currentDate = DateTime.now();
+  final _appbarTitleNotifier = ValueNotifier<String>('');
+  final _monthNameNotifier = ValueNotifier<String>('');
 
   late CrCalendarController _calendarController;
-  late String _appbarTitle;
-  late String _monthName;
 
   @override
   void initState() {
@@ -35,6 +37,8 @@ class _CalendarPageState extends State<CalendarPage> {
   @override
   void dispose() {
     _calendarController.dispose();
+    _appbarTitleNotifier.dispose();
+    _monthNameNotifier.dispose();
     super.dispose();
   }
 
@@ -44,7 +48,10 @@ class _CalendarPageState extends State<CalendarPage> {
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         centerTitle: false,
-        title: Text(_appbarTitle),
+        title: ValueListenableBuilder(
+          valueListenable: _appbarTitleNotifier,
+          builder: (ctx, value, child) => Text(value),
+        ),
         actions: [
           IconButton(
             tooltip: 'Go to current date',
@@ -69,10 +76,13 @@ class _CalendarPageState extends State<CalendarPage> {
                   _changeCalendarPage(showNext: false);
                 },
               ),
-              Text(
-                _monthName,
-                style: const TextStyle(
-                    fontSize: 16, color: violet, fontWeight: FontWeight.w600),
+              ValueListenableBuilder(
+                valueListenable: _monthNameNotifier,
+                builder: (ctx, value, child) => Text(
+                  value,
+                  style: const TextStyle(
+                      fontSize: 16, color: violet, fontWeight: FontWeight.w600),
+                ),
               ),
               IconButton(
                 icon: const Icon(Icons.arrow_forward_ios),
@@ -112,16 +122,14 @@ class _CalendarPageState extends State<CalendarPage> {
       : _calendarController.swipeToPreviousPage();
 
   void _onCalendarPageChanged(int year, int month) {
-    setState(() {
-      _setTexts(year, month);
-    });
+    _setTexts(year, month);
   }
 
   /// Set app bar text and month name over calendar.
   void _setTexts(int year, int month) {
     final date = DateTime(year, month);
-    _appbarTitle = date.format(kAppBarDateFormat);
-    _monthName = date.format(kMonthFormat);
+    _appbarTitleNotifier.value = date.format(kAppBarDateFormat);
+    _monthNameNotifier.value = date.format(kMonthFormat);
   }
 
   /// Show current month page.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.2 <3.0.0'
   flutter: ">=3.0.0"
 
 dependencies:
@@ -17,7 +17,7 @@ dependencies:
   cr_calendar:
     path: ../
 
-  intl: ^0.17.0
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/cr_calendar.dart
+++ b/lib/src/cr_calendar.dart
@@ -153,8 +153,8 @@ class CrCalendarController extends ChangeNotifier {
     final targetDate = dateToGoTo;
     final utcDay =
         DateTime.utc(targetDate.year, targetDate.month, targetDate.day);
-    final sought = utcDay.toJiffy();
-    final offset = date.toJiffy().diff(sought, Units.MONTH, true).ceil();
+    final sought = DateTime(utcDay.year, utcDay.month).toJiffy();
+    final offset = date.toJiffy().diff(sought, unit: Unit.month).ceil();
     if (selectDate) {
       clearSelected();
       selectedDate = utcDay;
@@ -318,7 +318,9 @@ class _CrCalendarState extends State<CrCalendar> {
           controller: widget.controller._getUpdatedPageController(),
           itemBuilder: (context, index) {
             final offset = index - widget.controller._initialPage;
-            final month = Jiffy(_initialDate).add(months: offset).dateTime;
+            final month = Jiffy.parseFromDateTime(_initialDate)
+                .add(months: offset)
+                .dateTime;
             return Container(
               color: widget.backgroundColor,
               child: MonthItem(
@@ -365,7 +367,7 @@ class _CrCalendarState extends State<CrCalendar> {
   /// Calculates month to display
   void _recalculateDisplayMonth(int offset) {
     widget.controller.date =
-        Jiffy([widget.initialDate.year, widget.initialDate.month])
+        Jiffy.parseFromList([widget.initialDate.year, widget.initialDate.month])
             .add(months: offset)
             .dateTime;
   }
@@ -376,7 +378,8 @@ class _CrCalendarState extends State<CrCalendar> {
       widget.controller.page = page;
       final offset = page - widget.controller._initialPage;
       _recalculateDisplayMonth(offset);
-      final date = Jiffy([widget.initialDate.year, widget.initialDate.month])
+      final date = Jiffy.parseFromList(
+              [widget.initialDate.year, widget.initialDate.month])
           .add(months: offset)
           .dateTime;
       widget.controller
@@ -416,19 +419,24 @@ class _CrCalendarState extends State<CrCalendar> {
         DateTime(widget.initialDate.year, widget.initialDate.month);
     if (widget.minDate != null) {
       final minMonth = DateTime(widget.minDate!.year, widget.minDate!.month);
-      widget.controller._initialPage = Jiffy(initialMoth)
+      widget.controller._initialPage = Jiffy.parseFromDateTime(initialMoth)
           .diff(
-            minMonth,
-            Units.MONTH,
+            minMonth.toJiffy(),
+            unit: Unit.month,
           )
           .toInt();
       widget.controller.page = widget.controller._initialPage;
     }
     if (widget.maxDate != null) {
       final maxMonth = DateTime(widget.maxDate!.year, widget.maxDate!.month);
-      widget.controller._maxPage =
-          Jiffy(initialMoth).diff(maxMonth, Units.MONTH).toInt().abs() +
-              widget.controller.page;
+      widget.controller._maxPage = Jiffy.parseFromDateTime(initialMoth)
+              .diff(
+                maxMonth.toJiffy(),
+                unit: Unit.month,
+              )
+              .toInt()
+              .abs() +
+          widget.controller.page;
     }
   }
 }

--- a/lib/src/cr_date_picker_dialog.dart
+++ b/lib/src/cr_date_picker_dialog.dart
@@ -162,8 +162,8 @@ class _CrDatePickerDialogState extends State<CrDatePickerDialog> {
 
   @override
   void initState() {
-    _initPicker();
     super.initState();
+    _initPicker();
   }
 
   @override

--- a/lib/src/extensions/datetime_ext.dart
+++ b/lib/src/extensions/datetime_ext.dart
@@ -1,5 +1,5 @@
 import 'package:jiffy/jiffy.dart';
 
 extension Converting on DateTime {
-  Jiffy toJiffy() => Jiffy(this);
+  Jiffy toJiffy() => Jiffy.parseFromDateTime(this);
 }

--- a/lib/src/month_calendar_widget.dart
+++ b/lib/src/month_calendar_widget.dart
@@ -86,8 +86,8 @@ class MonthCalendarWidgetState extends State<MonthCalendarWidget> {
 
     if (beginRange == null ||
         endRange == null ||
-        widget.begin.isAfter(endRange) ||
-        widget.end.isBefore(beginRange)) {
+        widget.begin.isAfter(endRange.toJiffy()) ||
+        widget.end.isBefore(beginRange.toJiffy())) {
       return;
     }
 
@@ -114,7 +114,9 @@ class MonthCalendarWidgetState extends State<MonthCalendarWidget> {
     if (selectedDay != null) {
       if (selectedDay.isSameOrAfter(widget.begin) &&
           selectedDay.isSameOrBefore(widget.end)) {
-        if (Jiffy(widget.begin).add(days: index).isSame(selectedDay)) {
+        if (Jiffy.parseFromJiffy(widget.begin)
+            .add(days: index)
+            .isSame(selectedDay)) {
           return true;
         }
       }
@@ -161,7 +163,8 @@ class MonthCalendarWidgetState extends State<MonthCalendarWidget> {
 
       return GestureDetector(
         onTap: () {
-          final tappedDate = Jiffy(widget.begin).add(days: index);
+          final tappedDate =
+              Jiffy.parseFromJiffy(widget.begin).add(days: index);
           widget.onDayTap?.call(tappedDate);
           if (widget.touchMode == TouchMode.singleTap) {
             _performDaySelecting(tappedDate);

--- a/lib/src/month_item.dart
+++ b/lib/src/month_item.dart
@@ -89,16 +89,20 @@ class MonthItemState extends State<MonthItem> {
     final display =
         DateTime.utc(widget.displayMonth.year, widget.displayMonth.month)
             .toJiffy();
-    _beginOffset = (widget.firstWeekDay.index > display.day - 1)
-        ? display.day - 1 + (WeekDay.values.length - widget.firstWeekDay.index)
-        : display.day - 1 - widget.firstWeekDay.index;
+    _beginOffset = (widget.firstWeekDay.index > display.dayOfWeek - 1)
+        ? display.dayOfWeek -
+            1 +
+            (WeekDay.values.length - widget.firstWeekDay.index)
+        : display.dayOfWeek - 1 - widget.firstWeekDay.index;
     _daysInMonth = display.daysInMonth;
-    _beginRange = Jiffy(Jiffy(display).subtract(days: _beginOffset));
-    _endRange = Jiffy(Jiffy(display).add(days: _daysInMonth - 1));
-    if (_endRange.day != WeekDay.sunday.index + 1) {
+    _beginRange = Jiffy.parseFromJiffy(
+        Jiffy.parseFromJiffy(display).subtract(days: _beginOffset));
+    _endRange = Jiffy.parseFromJiffy(
+        Jiffy.parseFromJiffy(display).add(days: _daysInMonth - 1));
+    if (_endRange.dayOfWeek != WeekDay.sunday.index + 1) {
       _endRange.add(
           days: WeekDay.values.length -
-              _endRange.day +
+              _endRange.dayOfWeek +
               widget.firstWeekDay.index);
     }
 
@@ -223,7 +227,7 @@ class MonthItemState extends State<MonthItem> {
     final end = _endRange;
     _weekCount = widget.forceSixWeek
         ? Contract.kMaxWeekPerMoth
-        : (end.diff(begin, Units.WEEK) + 1).toInt(); // inclusive
+        : (end.diff(begin, unit: Unit.week) + 1).toInt(); // inclusive
 
     final drawersForWeek = <List<EventProperties>>[];
     final weeks = List.generate(_weekCount, (index) {

--- a/lib/src/utils/calendar_utils.dart
+++ b/lib/src/utils/calendar_utils.dart
@@ -5,7 +5,8 @@ import '../../cr_calendar.dart';
 
 /// Returns date for [dayOfWeek] and for [row] in which it take place
 Jiffy mapWeekDayAndRowToDate(Jiffy beginRange, int dayOfWeek, int row) {
-  final begin = Jiffy(beginRange)..add(days: dayOfWeek - 1, weeks: row);
+  final begin = Jiffy.parseFromJiffy(beginRange)
+    ..add(days: dayOfWeek - 1, weeks: row);
   return begin;
 }
 

--- a/lib/src/utils/event_utils.dart
+++ b/lib/src/utils/event_utils.dart
@@ -49,8 +49,9 @@ List<EventProperties> resolveEventDrawersForWeek(
     int week, Jiffy monthStart, List<CalendarEventModel> events) {
   final drawers = <EventProperties>[];
 
-  final beginDate = Jiffy(monthStart).add(weeks: week);
-  final endDate = Jiffy(beginDate).add(days: Contract.kWeekDaysCount - 1);
+  final beginDate = Jiffy.parseFromJiffy(monthStart).add(weeks: week);
+  final endDate =
+      Jiffy.parseFromJiffy(beginDate).add(days: Contract.kWeekDaysCount - 1);
 
   for (final e in events) {
     final simpleEvent = _mapSimpleEventToDrawerOrNull(e, beginDate, endDate);
@@ -80,22 +81,23 @@ EventProperties? _mapSimpleEventToDrawerOrNull(
     event.end.minute,
   ).toJiffy();
 
-  if (jEnd.isBefore(begin, Units.DAY) || jBegin.isAfter(end, Units.DAY)) {
+  if (jEnd.isBefore(begin, unit: Unit.day) ||
+      jBegin.isAfter(end, unit: Unit.day)) {
     return null;
   }
 
   var beginDay = 1;
   if (jBegin.isSameOrAfter(begin)) {
-    beginDay = (begin.day - jBegin.day < 1)
-        ? 1 - (begin.day - jBegin.day)
-        : 1 - (begin.day - jBegin.day) + WeekDay.values.length;
+    beginDay = (begin.dayOfWeek - jBegin.dayOfWeek < 1)
+        ? 1 - (begin.dayOfWeek - jBegin.dayOfWeek)
+        : 1 - (begin.dayOfWeek - jBegin.dayOfWeek) + WeekDay.values.length;
   }
 
   var endDay = Contract.kWeekDaysCount;
   if (jEnd.isSameOrBefore(end)) {
-    endDay = (begin.day - jEnd.day < 1)
-        ? 1 - (begin.day - jEnd.day)
-        : 1 - (begin.day - jEnd.day) + WeekDay.values.length;
+    endDay = (begin.dayOfWeek - jEnd.dayOfWeek < 1)
+        ? 1 - (begin.dayOfWeek - jEnd.dayOfWeek)
+        : 1 - (begin.dayOfWeek - jEnd.dayOfWeek) + WeekDay.values.length;
   }
 
   return EventProperties(

--- a/lib/src/widgets/day_item.dart
+++ b/lib/src/widgets/day_item.dart
@@ -81,8 +81,8 @@ class DayItem extends StatelessWidget {
       return Colors.white;
     } else {
       return isWithinMonth
-          ? Theme.of(context).textTheme.caption?.color
-          : Theme.of(context).textTheme.caption?.color?.withOpacity(0.75);
+          ? Theme.of(context).textTheme.bodySmall?.color
+          : Theme.of(context).textTheme.bodySmall?.color?.withOpacity(0.75);
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: cr_calendar
 description: Awesome calendar with customizations, range picking and event showing.
-version: 1.0.0+1
+version: 1.1.0
 homepage: https://cleveroad.com
 repository: https://github.com/Cleveroad/cr_calendar
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.2 <3.0.0'
   flutter: ">=3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0
-  jiffy: ^5.0.0
+  intl: ^0.18.0
+  jiffy: ^6.1.0
   scrollable_positioned_list: ^0.3.2
 
 dev_dependencies:


### PR DESCRIPTION
- Updated dependencies
- Improve example app. Note: avoid using setState calls frequently on the page where the CrCalendar widget is used to improve performance.