### PR TITLE
New parameter: weeksToShow

### DIFF
--- a/example/lib/pages/calendar_page.dart
+++ b/example/lib/pages/calendar_page.dart
@@ -109,7 +109,7 @@ class _CalendarPageState extends State<CalendarPage> {
               onDayClicked: _showDayEventsInModalSheet,
               minDate: DateTime.now().subtract(const Duration(days: 1000)),
               maxDate: DateTime.now().add(const Duration(days: 180)),
-              //weeksToShow: const [0,1,2],
+              // weeksToShow: [0,1,2].toList(),
               //localizedWeekDaysBuilder: (weekDay) => LocalizedWeekDaysWidget(weekDay: weekDay),
             ),
           ),

--- a/example/lib/pages/calendar_page.dart
+++ b/example/lib/pages/calendar_page.dart
@@ -109,6 +109,7 @@ class _CalendarPageState extends State<CalendarPage> {
               onDayClicked: _showDayEventsInModalSheet,
               minDate: DateTime.now().subtract(const Duration(days: 1000)),
               maxDate: DateTime.now().add(const Duration(days: 180)),
+              //localizedWeekDaysBuilder: (weekDay) => LocalizedWeekDaysWidget(weekDay: weekDay),
             ),
           ),
         ],

--- a/example/lib/pages/calendar_page.dart
+++ b/example/lib/pages/calendar_page.dart
@@ -109,6 +109,7 @@ class _CalendarPageState extends State<CalendarPage> {
               onDayClicked: _showDayEventsInModalSheet,
               minDate: DateTime.now().subtract(const Duration(days: 1000)),
               maxDate: DateTime.now().add(const Duration(days: 180)),
+              //weeksToShow: const [0,1,2],
             ),
           ),
         ],

--- a/example/lib/widgets/localized_week_days_widget.dart
+++ b/example/lib/widgets/localized_week_days_widget.dart
@@ -1,0 +1,35 @@
+import 'package:cr_calendar/cr_calendar.dart';
+import 'package:cr_calendar_example/res/colors.dart';
+import 'package:flutter/material.dart';
+
+/// Widget that represents week days in row above calendar month view.
+class LocalizedWeekDaysWidget extends StatelessWidget {
+  const LocalizedWeekDaysWidget({
+    required this.weekDay,
+    super.key,
+  });
+
+  /// [String] value from [LocalizedWeekDaysBuilder].
+  final String weekDay;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Colors.transparent,
+          width: 0.3,
+        ),
+      ),
+      height: 40,
+      child: Center(
+        child: Text(
+          weekDay,
+          style: TextStyle(
+            color: violet.withOpacity(0.9),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/contract.dart
+++ b/lib/src/contract.dart
@@ -5,7 +5,8 @@ class Contract {
   static const kTabletAspectRatioW = 3;
   static const kTabletAspectRatioH = 4;
 
-  static const kMaxWeekPerMoth = 6;
+  static const kMaxWeekPerMonth = 6;
+  static const kWeeksToShowInMonth = <int>[0, 1, 2, 3, 4, 5];
   static const kWeekDaysCount = 7;
   static const k60PercentMultiplier = 0.6;
   static const k80PercentMultiplier = 0.8;

--- a/lib/src/contract.dart
+++ b/lib/src/contract.dart
@@ -19,4 +19,6 @@ class Contract {
   static const kYearsInLine = 3;
 
   static const kDefaultInitialPage = 4000;
+
+  static const kDefaultDayItemBorderWidth = 0.5;
 }

--- a/lib/src/cr_calendar.dart
+++ b/lib/src/cr_calendar.dart
@@ -217,10 +217,21 @@ class CrCalendar extends StatefulWidget {
     this.onSwipeCallbackDebounceMs = 100,
     this.minDate,
     this.maxDate,
+    this.weeksToShow,
     super.key,
   })  : assert(maxEventLines <= 6, 'maxEventLines should be less then 6'),
         assert(minDate == null || maxDate == null || minDate.isBefore(maxDate),
-            'minDate should be before maxDate');
+            'minDate should be before maxDate'),
+        assert(weeksToShow == null || weeksToShow.isNotEmpty,
+            'If provided, weeksToShow cannot be empty'),
+        assert(weeksToShow == null || weeksToShow.length <= 6,
+            'weeksToShow cannot contain more that 6 elements'),
+        assert(
+            weeksToShow == null ||
+                weeksToShow.every((element) => 0 <= element && element <= 5),
+            'weeksToShow can contain either 0,1,2,3,4 or 5 only.') {
+    weeksToShow?.sort();
+  }
 
   /// The minimum date until which the calendar can scroll
   final DateTime? minDate;
@@ -278,6 +289,11 @@ class CrCalendar extends StatefulWidget {
   ///
   /// Reduces number of callbacks when [CrCalendarController] goToDate is used.
   final int onSwipeCallbackDebounceMs;
+
+  /// List of weeks to show of a month, eg. first three weeks: 0,1,2
+  /// Takes a full 6 week month as a basis, therefore week numbers must be between 0 and 6, inclusive.
+  /// If [weeksToShow] is not null, [forceSixWeek] will have no effect.
+  final List<int>? weeksToShow;
 
   @override
   _CrCalendarState createState() => _CrCalendarState();
@@ -355,6 +371,7 @@ class _CrCalendarState extends State<CrCalendar> {
                 weekDaysBuilder: widget.weekDaysBuilder,
                 dayItemBuilder: widget.dayItemBuilder,
                 firstWeekDay: widget.firstDayOfWeek,
+                weeksToShow: widget.weeksToShow,
               ),
             );
           },

--- a/lib/src/cr_calendar.dart
+++ b/lib/src/cr_calendar.dart
@@ -4,7 +4,6 @@ import 'package:cr_calendar/src/extensions/datetime_ext.dart';
 import 'package:cr_calendar/src/models/calendar_event_model.dart';
 import 'package:cr_calendar/src/month_item.dart';
 import 'package:cr_calendar/src/utils/debouncer.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jiffy/jiffy.dart';
 
@@ -217,6 +216,7 @@ class CrCalendar extends StatefulWidget {
     this.onSwipeCallbackDebounceMs = 100,
     this.minDate,
     this.maxDate,
+    this.localizedWeekDaysBuilder,
     super.key,
   })  : assert(maxEventLines <= 6, 'maxEventLines should be less then 6'),
         assert(minDate == null || maxDate == null || minDate.isBefore(maxDate),
@@ -279,6 +279,21 @@ class CrCalendar extends StatefulWidget {
   /// Reduces number of callbacks when [CrCalendarController] goToDate is used.
   final int onSwipeCallbackDebounceMs;
 
+  /// Builder function for week day customization at the top of the calendar.
+  ///
+  /// When this parameter is not null, it will be called with each week days first
+  /// letter as a String, eg. S for Sunday, M for Monday, etc.
+  ///
+  /// When this parameter is not null, the first day of the week is determined
+  /// by the app's current locale, which is en_US in Flutter by default.
+  ///
+  /// The week day names will be translated for the current locale as well,
+  /// eg. if the current locale is German, then M for Montag, D for Dienstag etc.
+  ///
+  /// When this parameter is not null, [firstDayOfWeek] and [weekDaysBuilder]
+  /// parameters are ignored.
+  final LocalizedWeekDaysBuilder? localizedWeekDaysBuilder;
+
   @override
   _CrCalendarState createState() => _CrCalendarState();
 }
@@ -289,6 +304,8 @@ class _CrCalendarState extends State<CrCalendar> {
   late DateTime _initialDate;
 
   final _minPage = 1;
+
+  late WeekDay _firstWeekDay;
 
   @override
   void initState() {
@@ -307,6 +324,19 @@ class _CrCalendarState extends State<CrCalendar> {
     widget.controller.removeListener(_redraw);
     _onSwipeDebounce.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    final localizations = MaterialLocalizations.of(context);
+
+    if (widget.localizedWeekDaysBuilder != null) {
+      _firstWeekDay = WeekDay.values[localizations.firstDayOfWeekIndex];
+    } else {
+      _firstWeekDay = widget.firstDayOfWeek;
+    }
+
+    super.didChangeDependencies();
   }
 
   @override
@@ -354,7 +384,8 @@ class _CrCalendarState extends State<CrCalendar> {
                 },
                 weekDaysBuilder: widget.weekDaysBuilder,
                 dayItemBuilder: widget.dayItemBuilder,
-                firstWeekDay: widget.firstDayOfWeek,
+                firstWeekDay: _firstWeekDay,
+                localizedWeekDaysBuilder: widget.localizedWeekDaysBuilder,
               ),
             );
           },

--- a/lib/src/customization/builders.dart
+++ b/lib/src/customization/builders.dart
@@ -24,3 +24,8 @@ typedef PickerButtonBuilder = Widget? Function(Function? onPress);
 /// Callback for getting date range data from [CrDatePickerDialog].
 typedef OnDateRangeSelected = void Function(
     DateTime? rangeBegin, DateTime? rangeEnd);
+
+/// Builder for week day customization at the top of the calendar widget.
+/// The weekdays first letter in uppercase is passed as a String,
+/// eg. M (Monday), T (Tuesday) etc.
+typedef LocalizedWeekDaysBuilder = Widget Function(String weekDay);

--- a/lib/src/month_calendar_widget.dart
+++ b/lib/src/month_calendar_widget.dart
@@ -26,6 +26,7 @@ class MonthCalendarWidget extends StatefulWidget {
     required this.onDaySelected,
     required this.onRangeSelected,
     required this.touchMode,
+    required this.weeksToShow,
     this.currentDay,
     this.dayItemBuilder,
     this.onDayTap,
@@ -47,6 +48,7 @@ class MonthCalendarWidget extends StatefulWidget {
   final Function(List<CalendarEventModel>, Jiffy)? onDaySelected;
   final Function(List<CalendarEventModel>)? onRangeSelected;
   final TouchMode touchMode;
+  final List<int> weeksToShow;
 
   @override
   MonthCalendarWidgetState createState() => MonthCalendarWidgetState();
@@ -145,7 +147,7 @@ class MonthCalendarWidgetState extends State<MonthCalendarWidget> {
       (index) => Container(
         height: widget.itemHeight,
         child: Row(
-          children: _buildDays(index),
+          children: _buildDays(widget.weeksToShow[index], index),
         ),
       ),
     );
@@ -154,12 +156,11 @@ class MonthCalendarWidgetState extends State<MonthCalendarWidget> {
   }
 
   /// Build days in week
-  List<Widget> _buildDays(int week) {
+  List<Widget> _buildDays(int week, int row) {
     final days = List.generate(Contract.kWeekDaysCount, (i) {
       final index = week * Contract.kWeekDaysCount + i;
       final day = _getDisplayDay(index);
       final column = index % Contract.kWeekDaysCount;
-      final row = index ~/ Contract.kWeekDaysCount;
 
       return GestureDetector(
         onTap: () {

--- a/lib/src/month_item.dart
+++ b/lib/src/month_item.dart
@@ -6,7 +6,6 @@ import 'package:cr_calendar/src/models/event_count_keeper.dart';
 import 'package:cr_calendar/src/month_calendar_widget.dart';
 import 'package:cr_calendar/src/utils/event_utils.dart';
 import 'package:cr_calendar/src/widgets/default_weekday_widget.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jiffy/jiffy.dart';
 
@@ -29,6 +28,7 @@ class MonthItem extends StatefulWidget {
     this.eventTopPadding = 0,
     this.onDayTap,
     this.firstWeekDay = WeekDay.sunday,
+    this.localizedWeekDaysBuilder,
     super.key,
   });
 
@@ -46,6 +46,7 @@ class MonthItem extends StatefulWidget {
   final double? eventTopPadding;
   final TouchMode touchMode;
   final WeekDay firstWeekDay;
+  final LocalizedWeekDaysBuilder? localizedWeekDaysBuilder;
 
   @override
   MonthItemState createState() => MonthItemState();
@@ -114,9 +115,13 @@ class MonthItemState extends State<MonthItem> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: _getDaysOfWeek(),
+        LayoutBuilder(
+          builder: (context, constraint) {
+            final size = _getConstrainedSize(constraint);
+            return Row(
+              children: _getDaysOfWeek(size.width),
+            );
+          },
         ),
         Expanded(
           child: LayoutBuilder(
@@ -212,13 +217,39 @@ class MonthItemState extends State<MonthItem> {
   }
 
   /// Returns list of week days representation
-  List<Widget> _getDaysOfWeek() {
+  List<Widget> _getDaysOfWeek(double itemWidth) {
+    if (widget.localizedWeekDaysBuilder != null) {
+      return _getLocalizedDaysOfWeek(itemWidth);
+    }
+    final sortedWeekDays = sortWeekdays(widget.firstWeekDay);
     final week = List<Widget>.generate(WeekDay.values.length, (index) {
-      final sortedWeekDays = sortWeekdays(widget.firstWeekDay);
-      return widget.weekDaysBuilder?.call(sortedWeekDays[index]) ??
-          DefaultWeekdayWidget(day: sortedWeekDays[index]);
+      return Container(
+        width: itemWidth,
+        child: widget.weekDaysBuilder?.call(sortedWeekDays[index]) ??
+            DefaultWeekdayWidget(day: sortedWeekDays[index]),
+      );
     });
     return week;
+  }
+
+  List<Widget> _getLocalizedDaysOfWeek(double itemWidth) {
+    final localizations = MaterialLocalizations.of(context);
+    final result = <Widget>[];
+
+    var i = localizations.firstDayOfWeekIndex;
+    while (true) {
+      final weekday = localizations.narrowWeekdays[i];
+      result.add(Container(
+        width: itemWidth,
+        child: widget.localizedWeekDaysBuilder!.call(weekday),
+      ));
+      if (i == (localizations.firstDayOfWeekIndex - 1) % 7) {
+        break;
+      }
+      i = (i + 1) % 7;
+    }
+
+    return result;
   }
 
   /// Returns list of events for current month

--- a/lib/src/widgets/day_item.dart
+++ b/lib/src/widgets/day_item.dart
@@ -1,3 +1,4 @@
+import 'package:cr_calendar/src/contract.dart';
 import 'package:flutter/material.dart';
 
 ///Represent calendar day body
@@ -27,7 +28,10 @@ class DayItem extends StatelessWidget {
         Container(
           alignment: Alignment.topCenter,
           decoration: BoxDecoration(
-            border: Border.all(width: 0.5, color: Colors.black12),
+            border: Border.all(
+              width: Contract.kDefaultDayItemBorderWidth,
+              color: Colors.black12,
+            ),
             color: isSelectedDay || isWithinRange ? Colors.black12 : null,
           ),
           child: Column(

--- a/lib/src/widgets/default_weekday_widget.dart
+++ b/lib/src/widgets/default_weekday_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cr_calendar/src/contract.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +15,11 @@ class DefaultWeekdayWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+            width: Contract.kDefaultDayItemBorderWidth,
+            color: Colors.transparent),
+      ),
       height: 40,
       child: Center(
         child: Text(


### PR DESCRIPTION
I have added an optional parameter: weeksToShow.

First, let me explain the use case for this.
I want to use this calendar in the way it already is, a full-screen, Google Calendar-like widget, and it is excellent for that.
However, I also want to show a "reduced" version of the full calendar, where I can show an event and a few weeks before and after. Think of that like looking at the calendar through a window.

To be able to do that, I have decided to use the number of weeks to show instead of eg. providing an initial display date since then I would have had to deal with situations eg. the given date is not a Monday or Sunday or whatever the first day of the week is.

I tried my best to sanitize the user input while providing parameter documentation as well.
I also tried to keep code changes to a minimum.
I have corrected a typo in one of the constant members as well (kMaxWeekPerMoth -> kMaxWeekPerMonth).