### PR TITLE
New parameter: localized week days builder

### DIFF
--- a/example/lib/pages/calendar_page.dart
+++ b/example/lib/pages/calendar_page.dart
@@ -109,6 +109,7 @@ class _CalendarPageState extends State<CalendarPage> {
               onDayClicked: _showDayEventsInModalSheet,
               minDate: DateTime.now().subtract(const Duration(days: 1000)),
               maxDate: DateTime.now().add(const Duration(days: 180)),
+              //localizedWeekDaysBuilder: (weekDay) => LocalizedWeekDaysWidget(weekDay: weekDay),
             ),
           ),
         ],

--- a/example/lib/widgets/localized_week_days_widget.dart
+++ b/example/lib/widgets/localized_week_days_widget.dart
@@ -1,0 +1,35 @@
+import 'package:cr_calendar/cr_calendar.dart';
+import 'package:cr_calendar_example/res/colors.dart';
+import 'package:flutter/material.dart';
+
+/// Widget that represents week days in row above calendar month view.
+class LocalizedWeekDaysWidget extends StatelessWidget {
+  const LocalizedWeekDaysWidget({
+    required this.weekDay,
+    super.key,
+  });
+
+  /// [String] value from [LocalizedWeekDaysBuilder].
+  final String weekDay;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Colors.transparent,
+          width: 0.3,
+        ),
+      ),
+      height: 40,
+      child: Center(
+        child: Text(
+          weekDay,
+          style: TextStyle(
+            color: violet.withOpacity(0.9),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/contract.dart
+++ b/lib/src/contract.dart
@@ -19,4 +19,6 @@ class Contract {
   static const kYearsInLine = 3;
 
   static const kDefaultInitialPage = 4000;
+
+  static const kDefaultDayItemBorderWidth = 0.5;
 }

--- a/lib/src/cr_calendar.dart
+++ b/lib/src/cr_calendar.dart
@@ -4,7 +4,6 @@ import 'package:cr_calendar/src/extensions/datetime_ext.dart';
 import 'package:cr_calendar/src/models/calendar_event_model.dart';
 import 'package:cr_calendar/src/month_item.dart';
 import 'package:cr_calendar/src/utils/debouncer.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jiffy/jiffy.dart';
 
@@ -217,6 +216,7 @@ class CrCalendar extends StatefulWidget {
     this.onSwipeCallbackDebounceMs = 100,
     this.minDate,
     this.maxDate,
+    this.localizedWeekDaysBuilder,
     super.key,
   })  : assert(maxEventLines <= 6, 'maxEventLines should be less then 6'),
         assert(minDate == null || maxDate == null || minDate.isBefore(maxDate),
@@ -279,6 +279,21 @@ class CrCalendar extends StatefulWidget {
   /// Reduces number of callbacks when [CrCalendarController] goToDate is used.
   final int onSwipeCallbackDebounceMs;
 
+  /// Builder function for week day customization at the top of the calendar.
+  ///
+  /// When this parameter is not null, it will be called with each week days first
+  /// letter as a String, eg. S for Sunday, M for Monday, etc.
+  ///
+  /// When this parameter is not null, the first day of the week is determined
+  /// by the app's current locale, which is en_US in Flutter by default.
+  ///
+  /// The week day names will be translated for the current locale as well,
+  /// eg. if the current locale is German, then M for Montag, D for Dienstag etc.
+  ///
+  /// When this parameter is not null, [firstDayOfWeek] and [weekDaysBuilder]
+  /// parameters are ignored.
+  final LocalizedWeekDaysBuilder? localizedWeekDaysBuilder;
+
   @override
   _CrCalendarState createState() => _CrCalendarState();
 }
@@ -289,6 +304,8 @@ class _CrCalendarState extends State<CrCalendar> {
   late DateTime _initialDate;
 
   final _minPage = 1;
+
+  late WeekDay _firstWeekDay;
 
   @override
   void initState() {
@@ -307,6 +324,19 @@ class _CrCalendarState extends State<CrCalendar> {
     widget.controller.removeListener(_redraw);
     _onSwipeDebounce.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    final localizations = MaterialLocalizations.of(context);
+
+    if (widget.localizedWeekDaysBuilder != null) {
+      _firstWeekDay = WeekDay.values[localizations.firstDayOfWeekIndex];
+    } else {
+      _firstWeekDay = widget.firstDayOfWeek;
+    }
+
+    super.didChangeDependencies();
   }
 
   @override
@@ -354,7 +384,8 @@ class _CrCalendarState extends State<CrCalendar> {
                 },
                 weekDaysBuilder: widget.weekDaysBuilder,
                 dayItemBuilder: widget.dayItemBuilder,
-                firstWeekDay: widget.firstDayOfWeek,
+                firstWeekDay: _firstWeekDay,
+                localizedWeekDaysBuilder: widget.localizedWeekDaysBuilder,
               ),
             );
           },

--- a/lib/src/customization/builders.dart
+++ b/lib/src/customization/builders.dart
@@ -24,3 +24,8 @@ typedef PickerButtonBuilder = Widget? Function(Function? onPress);
 /// Callback for getting date range data from [CrDatePickerDialog].
 typedef OnDateRangeSelected = void Function(
     DateTime? rangeBegin, DateTime? rangeEnd);
+
+/// Builder for week day customization at the top of the calendar widget.
+/// The weekdays first letter in uppercase is passed as a String,
+/// eg. M (Monday), T (Tuesday) etc.
+typedef LocalizedWeekDaysBuilder = Widget Function(String weekDay);

--- a/lib/src/month_item.dart
+++ b/lib/src/month_item.dart
@@ -6,7 +6,6 @@ import 'package:cr_calendar/src/models/event_count_keeper.dart';
 import 'package:cr_calendar/src/month_calendar_widget.dart';
 import 'package:cr_calendar/src/utils/event_utils.dart';
 import 'package:cr_calendar/src/widgets/default_weekday_widget.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jiffy/jiffy.dart';
 
@@ -29,6 +28,7 @@ class MonthItem extends StatefulWidget {
     this.eventTopPadding = 0,
     this.onDayTap,
     this.firstWeekDay = WeekDay.sunday,
+    this.localizedWeekDaysBuilder,
     super.key,
   });
 
@@ -46,6 +46,7 @@ class MonthItem extends StatefulWidget {
   final double? eventTopPadding;
   final TouchMode touchMode;
   final WeekDay firstWeekDay;
+  final LocalizedWeekDaysBuilder? localizedWeekDaysBuilder;
 
   @override
   MonthItemState createState() => MonthItemState();
@@ -114,9 +115,13 @@ class MonthItemState extends State<MonthItem> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: _getDaysOfWeek(),
+        LayoutBuilder(
+          builder: (context, constraint) {
+            final size = _getConstrainedSize(constraint);
+            return Row(
+              children: _getDaysOfWeek(size.width),
+            );
+          },
         ),
         Expanded(
           child: LayoutBuilder(
@@ -212,13 +217,39 @@ class MonthItemState extends State<MonthItem> {
   }
 
   /// Returns list of week days representation
-  List<Widget> _getDaysOfWeek() {
+  List<Widget> _getDaysOfWeek(double itemWidth) {
+    if (widget.localizedWeekDaysBuilder != null) {
+      return _getLocalizedDaysOfWeek(itemWidth);
+    }
+    final sortedWeekDays = sortWeekdays(widget.firstWeekDay);
     final week = List<Widget>.generate(WeekDay.values.length, (index) {
-      final sortedWeekDays = sortWeekdays(widget.firstWeekDay);
-      return widget.weekDaysBuilder?.call(sortedWeekDays[index]) ??
-          DefaultWeekdayWidget(day: sortedWeekDays[index]);
+      return Container(
+        width: itemWidth,
+        child: widget.weekDaysBuilder?.call(sortedWeekDays[index]) ??
+            DefaultWeekdayWidget(day: sortedWeekDays[index]),
+      );
     });
     return week;
+  }
+
+  List<Widget> _getLocalizedDaysOfWeek(double itemWidth) {
+    final localizations = MaterialLocalizations.of(context);
+    final result = <Widget>[];
+
+    var i = localizations.firstDayOfWeekIndex;
+    while (true) {
+      final weekday = localizations.narrowWeekdays[i];
+      result.add(Container(
+        width: itemWidth,
+        child: widget.localizedWeekDaysBuilder!.call(weekday),
+      ));
+      if (i == (localizations.firstDayOfWeekIndex - 1) % 7) {
+        break;
+      }
+      i = (i + 1) % 7;
+    }
+
+    return result;
   }
 
   /// Returns list of events for current month

--- a/lib/src/widgets/day_item.dart
+++ b/lib/src/widgets/day_item.dart
@@ -1,3 +1,4 @@
+import 'package:cr_calendar/src/contract.dart';
 import 'package:flutter/material.dart';
 
 ///Represent calendar day body
@@ -27,7 +28,10 @@ class DayItem extends StatelessWidget {
         Container(
           alignment: Alignment.topCenter,
           decoration: BoxDecoration(
-            border: Border.all(width: 0.5, color: Colors.black12),
+            border: Border.all(
+              width: Contract.kDefaultDayItemBorderWidth,
+              color: Colors.black12,
+            ),
             color: isSelectedDay || isWithinRange ? Colors.black12 : null,
           ),
           child: Column(

--- a/lib/src/widgets/default_weekday_widget.dart
+++ b/lib/src/widgets/default_weekday_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cr_calendar/src/contract.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +15,11 @@ class DefaultWeekdayWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+            width: Contract.kDefaultDayItemBorderWidth,
+            color: Colors.transparent),
+      ),
       height: 40,
       child: Center(
         child: Text(


### PR DESCRIPTION
Added a new optional parameter: localizedWeekDaysBuilder.

User case:

Currently, the weekDays widget at the top of the calendar works through two parameters: firstDayOfWeek and weekDaysBuilder. The abbreviations are hard-coded to work in English only, while the first day of the week is by default Sunday (as per US English), however, that can be changed through firstDayOfWeek.

This behavior above does not support localizations at all. That is, determining the first day of the week and showing day abbreviations based on the app's current locale. An example of this is Flutter's default [showDateRangePicker](https://api.flutter.dev/flutter/material/showDateRangePicker.html) and [showDatePicker](https://api.flutter.dev/flutter/material/showDatePicker.html).

The proposed changes work as the following: when the new parameter is null, the current behavior is in effect, ie. backward compatible. When the builder function is not null, then the provided values (if any) of firstDayOfWeek and weekDaysBuilder are ignored. firstDayOfWeek will be initialized based on the app's current locale, while weekDaysBuilder is not used at all.

The logic to determine the first day of the week and the week abbreviations in **_getLocalizedDaysOfWeek()** in **lib/src/month_item.dart** is based on the default Flutter implementation in **..\flutter\packages\flutter\lib\src\material\date_picker.dart**, **List<Widget> _getDayHeaders(TextStyle headerStyle, MaterialLocalizations localizations){...}** function. I had to rewrite the code from a for loop to a while loop because of one of this library's linter rules ([literal_only_boolean_expressions](https://dart.dev/tools/linter-rules/literal_only_boolean_expressions) specifically).

While implementing this feature, I have also recognized that the weekday letters are not completely aligned with the date numbers below them. In English, this was not very noticeable, but in languages where the abbreviation consists of 2 letters (eg. Sz) it was quite obvious. For this to work properly, I have wrapped each weekday widget with a Container that has the same width as the day item widgets below them. In addition to this, borders also have an effect; the weekday widgets must have a border with the same width as the day items below, most likely with a transient color. I have updated the default DayItem and DefaultWeekdayWidget widgets to have the same border size.

I have also extended the example project to show how this builder function works.