### PR TITLE
Not fitted event counter fix

### DIFF
--- a/lib/src/utils/event_utils.dart
+++ b/lib/src/utils/event_utils.dart
@@ -109,10 +109,7 @@ EventProperties? _mapSimpleEventToDrawerOrNull(
 
 /// Map EventDrawers to EventsLineDrawer and sort them by duration on current week
 List<EventsLineDrawer> placeEventsToLines(
-    List<EventProperties> events, int maxLines) {
-  final copy = <EventProperties>[...events]
-    ..sort((a, b) => b.size().compareTo(a.size()));
-
+    List<EventProperties> copy, int maxLines) {
   final lines = List.generate(maxLines, (index) {
     final lineDrawer = EventsLineDrawer();
     for (var day = 1; day <= Contract.kWeekDaysCount; day++) {
@@ -139,17 +136,13 @@ List<NotFittedWeekEventCount> calculateOverflowedEvents(
     List<List<EventProperties>> monthEvents, int maxLines) {
   final weeks = <NotFittedWeekEventCount>[];
   for (final week in monthEvents) {
-    var countList = List.filled(WeekDay.values.length, 0);
+    final countList = List.filled(WeekDay.values.length, 0);
 
     for (final event in week) {
       for (var i = event.begin - 1; i < event.end; i++) {
         countList[i]++;
       }
     }
-    countList = countList.map((count) {
-      final notFitCount = count - maxLines;
-      return notFitCount <= 0 ? 0 : notFitCount;
-    }).toList();
     weeks.add(NotFittedWeekEventCount(countList));
   }
   return weeks;


### PR DESCRIPTION
There was a bug in not fitted event counter.

For example, have maxEventLines events from the 5th to the 7th (3 days long each). Add an event from the 7th to the 8th (2 days long). It won't be shown because of how the algorithm works (prioritizes longer events), which is fine. +1 will appear on the 7th, which is also fine. However, +1 won't appear on the 8th, however, it should. 

I have modified the implementation a little bit to fix this error. When events are selected to be drawn, they are removed from the original event list. At the end of the event placing algorithm, we can know for sure that leftover events are not shown, and there should be a +1 on each day they take place.