### PR TITLE
Fix: Pass correct type to isInRange extension for calculateAvailableEventsForRange function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1
+
+- Updated dependencies
+  
 # 1.2.1
 
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.3.1
+# 1.3.0
 
 - Updated dependencies
   

--- a/lib/src/utils/event_utils.dart
+++ b/lib/src/utils/event_utils.dart
@@ -33,10 +33,12 @@ List<CalendarEventModel> calculateAvailableEventsForRange(
         DateTime.utc(event.begin.year, event.begin.month, event.begin.day);
     final eventEndUtc =
         DateTime.utc(event.end.year, event.end.month, event.end.day);
-    if (eventStartUtc.toJiffy().isInRange(start, end) ||
-        eventEndUtc.toJiffy().isInRange(start, end) ||
-        (start?.isInRange(eventStartUtc, eventEndUtc) ?? false) ||
-        (end?.isInRange(eventStartUtc, eventEndUtc) ?? false)) {
+    final eventStartUtcJiffy = eventStartUtc.toJiffy();
+    final eventEndUtcJiffy = eventEndUtc.toJiffy();
+    if (eventStartUtcJiffy.isInRange(start, end) ||
+        eventEndUtcJiffy.isInRange(start, end) ||
+        (start?.isInRange(eventStartUtcJiffy, eventEndUtcJiffy) ?? false) ||
+        (end?.isInRange(eventStartUtcJiffy, eventEndUtcJiffy) ?? false)) {
       eventsHappen.add(event);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cr_calendar
 description: Awesome calendar with customizations, range picking and event showing.
-version: 1.2.1
+version: 1.3.0
 homepage: https://cleveroad.com
 repository: https://github.com/Cleveroad/cr_calendar
 
@@ -19,8 +19,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.18.1
-  jiffy: ^6.2.1
+  intl: ^0.19.0
+  jiffy: ^6.3.1
   scrollable_positioned_list: ^0.3.8
 
 dev_dependencies:


### PR DESCRIPTION
Raw DateTime was being passed to  isInRange extension function causing a crash. It went unnoticed as the extension uses dynamic parameters. This PR contains fix for the same